### PR TITLE
İmajlara chrome kurulumunu ekle

### DIFF
--- a/srv/scripts/desktop.sh
+++ b/srv/scripts/desktop.sh
@@ -7,6 +7,7 @@ source <(curl -fsSL https://she.alaturka.io/source) -boot
 
 export locale=tr_TR.UTF-8
 export base_use_experimental=true
+export chrome_install_upstream=true
 export golang_use_experimental=true
 export tmux_login_shell=true
 
@@ -26,6 +27,7 @@ enter github.com/omu/debian/lib/scripts
 	leave
 
 	enter ./runtime
+		try chrome
 		try common
 		try ruby
 		try javascript

--- a/srv/scripts/ruby.sh
+++ b/srv/scripts/ruby.sh
@@ -15,6 +15,7 @@ enter github.com/omu/debian/lib/scripts
 	leave
 
 	enter ./runtime
+		try chrome
 		try common
 		try ruby
 		try javascript

--- a/srv/scripts/server.sh
+++ b/srv/scripts/server.sh
@@ -24,6 +24,7 @@ enter github.com/omu/debian/lib/scripts
 	leave
 
 	enter ./runtime
+		try chrome
 		try common
 		try ruby
 		try javascript


### PR DESCRIPTION
Özellikle CI'da çalışan Rails entegrasyon testleri için `chromedriver` Ruby imajında kurulu gelmeli. Bu vesileyle `chrome` diğer imajlara da eklendi.